### PR TITLE
Ajuste para correção da geração do XML

### DIFF
--- a/src/maxiPago/DataContract/Transactional/Address.java
+++ b/src/maxiPago/DataContract/Transactional/Address.java
@@ -3,7 +3,7 @@ package maxiPago.DataContract.Transactional;
 public class Address {
 	
 	//Attributes
-	private int id;
+	private Integer id;
 	private String name;
 	private String address;
 	private String address2;
@@ -42,14 +42,14 @@ public class Address {
 		return type;
 	}
 	
-	public void setId(int id) {
+	public void setId(Integer id) {
 		this.id = id;
 	}
-	
-	public int getId() {
+
+	public Integer getId() {
 		return id;
 	}
-	
+
 	public String getName() {
 		return this.name;
 	}


### PR DESCRIPTION
Com o campo id como int, ele sempre será enviado no xml com valor 0.

<id>0</id>

Isso está gerando um erro na autorização com a opção de salvar e gerar o token do cartão.

Com o campo id como Integer ele tem como valor default null. Assim, quando não informado, o mesmo não vai para o xml com valor 0 e a rotina de autorização com a opção de salvar o cartão e gerar o token funciona normalmente,